### PR TITLE
fix: incorrect warning for useFetch

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -144,7 +144,7 @@ export function useFetch<
     watch: watch === false ? [] : [_fetchOptions, _request, ...(watch || [])],
   }
 
-  if (import.meta.dev && import.meta.client) {
+  if (import.meta.dev) {
     // @ts-expect-error private property
     _asyncDataOptions._functionName = opts._functionName || 'useFetch'
   }


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/nuxt/nuxt/issues/31211
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
should fix above issue by allowing passing useFetch even on server. Not sure what perf cost is
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
